### PR TITLE
feat(gateway): promote GitHub Copilot to a stable backend

### DIFF
--- a/apps/gateway/src/backends.ts
+++ b/apps/gateway/src/backends.ts
@@ -90,6 +90,31 @@ const backends: AIBackend[] = [
       return ["exec", prompt, "--full-auto", "--skip-git-repo-check"];
     },
   },
+  {
+    id: "copilot",
+    name: "GitHub Copilot",
+    command: "copilot",
+    instructionPath: ".github/copilot-instructions.md",
+    stability: "stable",
+    guardType: "flag",             // --allow-all-tools / --allow-all
+    supportsResume: true,
+    supportsAgentType: false,
+    supportsNativeWorktree: false,
+    supportsStructuredOutput: true,
+    buildArgs(prompt, opts) {
+      // JSONL: one event per line, final {"type":"result","sessionId","exitCode"}.
+      const args = ["-p", prompt, "--output-format", "json"];
+      // Non-interactive runs must auto-approve and never stop to ask the user.
+      args.push(opts.fullAccess ? "--allow-all" : "--allow-all-tools", "--no-ask-user");
+      if (!opts.skipResume && opts.resumeSessionId) {
+        args.push("--session-id", opts.resumeSessionId);
+      } else if (!opts.skipResume && opts.continue) {
+        args.push("--continue");
+      }
+      if (opts.model) args.push("--model", opts.model);
+      return args;
+    },
+  },
 
   // ── Beta backends ─────────────────────────────────────────────
   {
@@ -109,24 +134,6 @@ const backends: AIBackend[] = [
   },
 
   // ── Experimental backends ─────────────────────────────────────
-  {
-    id: "copilot",
-    name: "GitHub Copilot",
-    command: "copilot",
-    instructionPath: ".github/copilot-instructions.md",
-    stability: "experimental",
-    guardType: "none",
-    supportsResume: false,
-    supportsAgentType: false,
-    supportsNativeWorktree: false,
-    supportsStructuredOutput: false,
-    buildArgs(prompt, opts) {
-      const args = ["-p", prompt];
-      if (opts.fullAccess) args.push("--allow-all-tools");
-      if (opts.model) args.push("--model", opts.model);
-      return args;
-    },
-  },
   {
     id: "cursor",
     name: "Cursor CLI",

--- a/packages/orchestrator/src/agent-session.ts
+++ b/packages/orchestrator/src/agent-session.ts
@@ -609,6 +609,12 @@ export class AgentSession {
                 saveSessionId(this.agentId, msg.session_id);
                 console.log(`[Agent ${this.name}] Session ID: ${msg.session_id}`);
               }
+              // GitHub Copilot reports its sessionId only on the final result line.
+              if (msg.type === "result" && msg.sessionId) {
+                this.sessionId = msg.sessionId;
+                saveSessionId(this.agentId, msg.sessionId);
+                console.log(`[Agent ${this.name}] Session ID: ${msg.sessionId}`);
+              }
               if (msg.type === "assistant" && msg.message?.content) {
                 // Live token usage from per-turn usage (dedup same-turn repeats)
                 if (msg.message.usage) {
@@ -670,6 +676,13 @@ export class AgentSession {
                 }
                 // (conversationLog removed — recovery context now uses @bit-office/memory's
                 //  structured SessionSummary instead of raw message fragments)
+              } else if (msg.type === "assistant.message" && msg.data?.content) {
+                // GitHub Copilot JSONL: final answer arrives as one assistant.message
+                // (token deltas use assistant.message_delta, which we skip to avoid dupes).
+                const text = msg.data.content as string;
+                this.stdoutBuffer += text + "\n";
+                handleTextLine(text, true);
+                this.persistWorkState("running");
               } else if (msg.type === "result") {
                 // Result message: authoritative session total from msg.usage
                 if (msg.usage) {


### PR DESCRIPTION
## What

Promotes the GitHub Copilot adapter in `apps/gateway/src/backends.ts` from `experimental` to `stable`, bringing it to parity with the Claude/Codex stable adapters. Previously Copilot just spawned a bare `-p` prompt: no structured output, no session resume, and it could hang on a permission prompt.

## Why

The CLI is mature enough to drive autonomously. Wiring up the documented one-shot flags makes it usable for multi-agent runs like the existing stable backends.

## Changes

- `apps/gateway/src/backends.ts`: copilot is now `stable`, `supportsResume: true`, `supportsStructuredOutput: true`, `guardType: "flag"`. `buildArgs` emits `--output-format json`, auto-approves with `--allow-all-tools` (`--allow-all` on full access) and `--no-ask-user`, resumes via `--session-id`, and passes `--model` through.
- `packages/orchestrator/src/agent-session.ts`: parse Copilot JSONL: capture `sessionId` from the final `result` line for resume, and surface the final `assistant.message` content (deltas skipped to avoid dupes).

## Verification (real copilot v1.0.65, authed)

- `pnpm install`; gateway bundles via tsup; orchestrator/gateway typecheck show only 2 pre-existing errors (`prompt-templates.ts:406`, `telegram-channel.ts:391`), unchanged by this PR.
- Smoke: ran a JSON one-shot, captured `sessionId`/`exitCode:0`, then resumed with the same `--session-id` and Copilot correctly recalled prior context.
- Memory suite: 53 pass / 1 fail, pre-existing and unrelated.

## Licensing

This repo has no LICENSE file. Contribution terms are unclear; please confirm how you want external contributions handled before merging.