### PR TITLE
fix: resolve ENOENT when spawning backend CLIs on Windows

### DIFF
--- a/apps/gateway/src/backends.ts
+++ b/apps/gateway/src/backends.ts
@@ -240,20 +240,23 @@ const VERSION_PROBES: Record<string, string> = {
  * `which`/`execSync` above run through a POSIX shell (Git Bash on Windows), so resolved
  * paths come back like "/c/Users/arsla/.local/bin/claude". Node's spawn() on Windows goes
  * through the native Win32 CreateProcess API, which doesn't understand that syntax and
- * fails with ENOENT. Convert to a native Windows path (and add .exe/.cmd if needed) so
- * spawn() can actually find the binary.
+ * fails with ENOENT. Convert to a native Windows path so spawn() can actually find the
+ * binary.
+ *
+ * npm/global installs on Windows commonly create BOTH an extensionless POSIX shell shim
+ * and a .cmd/.exe wrapper side by side. Git Bash's `which` may return the extensionless
+ * shim, which exists on disk but is a shell script Win32 spawn() cannot execute directly.
+ * So a real Windows-executable candidate (.exe/.cmd/.bat) must be preferred FIRST, falling
+ * back to the bare converted path only if none of those exist.
  */
 function toNativeWindowsPath(posixPath: string): string {
   const match = posixPath.match(/^\/([a-zA-Z])\/(.*)$/);
   if (!match) return posixPath;
   const [, drive, rest] = match;
-  let winPath = `${drive.toUpperCase()}:\\${rest.replace(/\//g, "\\")}`;
-  if (!existsSync(winPath)) {
-    for (const ext of [".exe", ".cmd", ".bat"]) {
-      if (existsSync(winPath + ext)) {
-        winPath += ext;
-        break;
-      }
+  const winPath = `${drive.toUpperCase()}:\\${rest.replace(/\//g, "\\")}`;
+  for (const ext of [".exe", ".cmd", ".bat"]) {
+    if (existsSync(winPath + ext)) {
+      return winPath + ext;
     }
   }
   return winPath;

--- a/apps/gateway/src/backends.ts
+++ b/apps/gateway/src/backends.ts
@@ -236,6 +236,29 @@ const VERSION_PROBES: Record<string, string> = {
   sapling: "sp --version 2>&1 | grep -iq sapling",
 };
 
+/**
+ * `which`/`execSync` above run through a POSIX shell (Git Bash on Windows), so resolved
+ * paths come back like "/c/Users/arsla/.local/bin/claude". Node's spawn() on Windows goes
+ * through the native Win32 CreateProcess API, which doesn't understand that syntax and
+ * fails with ENOENT. Convert to a native Windows path (and add .exe/.cmd if needed) so
+ * spawn() can actually find the binary.
+ */
+function toNativeWindowsPath(posixPath: string): string {
+  const match = posixPath.match(/^\/([a-zA-Z])\/(.*)$/);
+  if (!match) return posixPath;
+  const [, drive, rest] = match;
+  let winPath = `${drive.toUpperCase()}:\\${rest.replace(/\//g, "\\")}`;
+  if (!existsSync(winPath)) {
+    for (const ext of [".exe", ".cmd", ".bat"]) {
+      if (existsSync(winPath + ext)) {
+        winPath += ext;
+        break;
+      }
+    }
+  }
+  return winPath;
+}
+
 /** Check which AI CLI tools are installed on this machine.
  *  Also resolves each detected backend's command to its absolute path
  *  so that spawn() works even if the child process env has a different PATH. */
@@ -253,8 +276,9 @@ export function detectBackends(): string[] {
       }
       // Resolve absolute path so spawn() doesn't depend on child env PATH
       try {
-        const absPath = execSync(`which ${backend.command}`, { encoding: "utf-8", timeout: 3000 }).trim();
+        let absPath = execSync(`which ${backend.command}`, { encoding: "utf-8", timeout: 3000 }).trim();
         if (absPath && absPath.startsWith("/")) {
+          if (process.platform === "win32") absPath = toNativeWindowsPath(absPath);
           backend.command = absPath;
           console.log(`[backends] ${backend.id}: resolved to ${absPath}`);
         }


### PR DESCRIPTION
Fixes #15

## Problem

On Windows, every agent task fails immediately with:

```
"/c/Users/<name>/.local/bin/claude" not found. Please install it and make sure it's in your PATH.
```

even when the CLI is installed and works fine from a terminal.

## Root cause

\`detectBackends()\` in \`apps/gateway/src/backends.ts\` resolves each backend's absolute path via \`which\`, executed through \`execSync\`. On Windows this runs through a POSIX-style shell (Git Bash), so it returns a path like \`/c/Users/<name>/.local/bin/claude\`. That string is stored as \`backend.command\` and later passed directly to Node's \`spawn()\` in \`packages/orchestrator/src/agent-session.ts\`. On Windows, \`spawn()\` uses the native Win32 \`CreateProcess\` API, which doesn't understand POSIX-style paths — only native ones like \`C:\Users\...\`. The spawn fails with \`ENOENT\`.

## Fix

Added \`toNativeWindowsPath()\` in \`backends.ts\`, applied only when \`process.platform === "win32"\`:

- Converts \`/c/Users/name/...\` → \`C:\Users\name\...\`
- Probes for \`.exe\`/\`.cmd\`/\`.bat\` if the bare path doesn't exist on disk (the installed binary is typically \`claude.exe\`, not a bare \`claude\`)

No behavior change on macOS/Linux — the conversion is a no-op there.

## Testing

- Reproduced the bug on Windows 11 with Claude Code installed via \`.local/bin/claude.exe\`.
- Confirmed \`detectBackends()\` previously resolved to \`/c/Users/.../claude\`, which failed on \`spawn()\`.
- Applied the fix, restarted the gateway, created a project + agent, and sent a message — the agent now spawns and responds correctly instead of failing with ENOENT.

## Note

I don't have a macOS/Linux machine to verify no regression there, but the change is a no-op unless \`process.platform === "win32"\`, so existing behavior on those platforms is unchanged.

@longyangxi would appreciate a review when you get a chance.